### PR TITLE
Systemd Files for Ubuntu 16

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,14 +42,6 @@
     virtualenv={{ openbazaar_user_home_directory }}/openbazaar/venv
     state=present
 
-# TODO: Figure out why this is required
-- name: Install html5lib
-  pip:
-    name=html5lib
-    version=0.999
-    state=present
-    virtualenv={{ openbazaar_user_home_directory }}/openbazaar/venv
-
 - name: Set git directory ownership
   file:
     path={{ openbazaar_user_home_directory }}/openbazaar

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,9 @@
     - sqlite3
     - libffi-dev
     - libssl-dev
+    - python-dev
+    - python-virtualenv
+    - python-pip
 
 # Group and user
 - name: Create the service group

--- a/tasks/seed.yml
+++ b/tasks/seed.yml
@@ -31,8 +31,23 @@
     owner={{ openbazaar_user }}
     group={{ openbazaar_group }}
     mode=0644
-  notify:
-    - restart seed
 
-- name: Start Seed Server
-  service: name=openbazaarseedd state=started
+- name: Start Seed Server - Upstart
+  service: name=openbazaard state=started
+  when: ansible_distribution == "Ubuntu" and ansible_lsb.major_release|int <= 14.04
+
+- name: Install systemd script
+  template:
+    src=server/openbazaar_systemd.service.j2
+    dest=/etc/systemd/system/openbazaarseedd.service
+    owner={{ openbazaar_user }}
+    group={{ openbazaar_group }}
+    mode=0644
+  when: ansible_distribution == "Ubuntu" and ansible_lsb.major_release|int > 14.04
+
+- name: Start seed Server - Systemd
+  systemd:
+    state: restarted
+    daemon_reload: yes
+    name: openbazaarseedd
+  when: ansible_distribution == "Ubuntu" and ansible_lsb.major_release|int > 14.04

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -25,8 +25,24 @@
     owner={{ openbazaar_user }}
     group={{ openbazaar_group }}
     mode=0644
-  notify:
-    - restart server
 
-- name: Start Server
+- name: Start Server - Upstart
   service: name=openbazaard state=started
+  when: ansible_distribution == "Ubuntu" and ansible_lsb.major_release|int <= 14.04
+
+- name: Install systemd script
+  template:
+    src=server/openbazaar_systemd.service.j2
+    dest=/etc/systemd/system/openbazaard.service
+    owner={{ openbazaar_user }}
+    group={{ openbazaar_group }}
+    mode=0644
+  when: ansible_distribution == "Ubuntu" and ansible_lsb.major_release|int > 14.04
+
+- name: Start Server - Systemd
+  systemd:
+    state: restarted
+    daemon_reload: yes
+    name: openbazaard
+  when: ansible_distribution == "Ubuntu" and ansible_lsb.major_release|int > 14.04
+

--- a/templates/seed/openbazaar_systemd.service.j2
+++ b/templates/seed/openbazaar_systemd.service.j2
@@ -1,0 +1,18 @@
+[Unit]
+Description=Openbazaar Seed
+After=network.target
+
+[Service]
+Type=simple
+User={{ openbazaar_user }}
+Group={{ openbazaar_group }}
+ExecStart={{ openbazaar_user_home_directory }}/openbazaar/venv/bin/python \
+    {{ openbazaar_user_home_directory }}/openbazaar/httpseed.py start \
+    -p {{ openbazaar_seed_http_port }} \
+    {{ openbazaar_additional_flags }}
+WorkingDirectory=/home/openbazaar
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target
+

--- a/templates/server/openbazaar_systemd.service.j2
+++ b/templates/server/openbazaar_systemd.service.j2
@@ -1,0 +1,21 @@
+[Unit]
+Description=Openbazaar
+After=network.target
+
+[Service]
+Type=simple
+User={{ openbazaar_user }}
+Group={{ openbazaar_group }}
+ExecStart={{ openbazaar_user_home_directory }}/openbazaar/venv/bin/python \
+    {{ openbazaar_user_home_directory }}/openbazaar/openbazaard.py start \
+    -p {{ openbazaar_dht_port }} \
+    -r {{ openbazaar_rest_port }} \
+    -w {{ openbazaar_websocket_port }} \
+    -b {{ openbazaar_heartbeat_port }} \
+    -a {{ openbazaar_allowed_ip }} \
+    {{ openbazaar_additional_flags }}
+WorkingDirectory=/home/openbazaar
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds systemd service files. These patches are backwards compatible with Ubuntu <=14.04 by falling back to upstart. I was testing on vagrant which required python-virtualenv apt package, so I brought back those dependencies.

I also removed the pinned html5 package. That was resolved with https://github.com/OpenBazaar/OpenBazaar-Server/pull/475

Also, have you considered opening a PR to get your changes into the mainline package for this role?